### PR TITLE
plot label CMSvDAS 2022 to 2023

### DIFF
--- a/Dilepton-Protons.ipynb
+++ b/Dilepton-Protons.ipynb
@@ -2623,9 +2623,9 @@
     "\n",
     "plt.style.use(mplhep.style.CMS)\n",
     "plt.sca( axes[0] )\n",
-    "mplhep.cms.label(llabel=\"Preliminary\", rlabel=\"CMSvDAS 2022\")\n",
+    "mplhep.cms.label(llabel=\"Preliminary\", rlabel=\"CMSvDAS 2023\")\n",
     "plt.sca( axes[1] )\n",
-    "mplhep.cms.label(llabel=\"Preliminary\", rlabel=\"CMSvDAS 2022\")\n"
+    "mplhep.cms.label(llabel=\"Preliminary\", rlabel=\"CMSvDAS 2023\")\n"
    ]
   },
   {


### PR DESCRIPTION
I changed the labelling of the penultimate plots, that were with "CMSvDAS 2022"